### PR TITLE
ignore godot-generated files in the docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Godot-specific ignores
 .import/
+documentation_assets/*.png.import
 
 # Imported translations (automatically generated from CSV files)
 *.translation


### PR DESCRIPTION
This allows people to cleanly use this project as a submodule in a project where the godot project is at the top level without needing to deal with godot dirtying the submodule.